### PR TITLE
Allow context manager to fail if lock was not acquired

### DIFF
--- a/redlock/__init__.py
+++ b/redlock/__init__.py
@@ -1,2 +1,2 @@
-from .lock import RedLock, RedLockFactory
+from .lock import RedLock, RedLockFactory, RedLockError
 __VERSION__ = '1.0.0'

--- a/redlock/lock.py
+++ b/redlock/lock.py
@@ -101,7 +101,8 @@ class RedLock(object):
         self.quorum = len(self.redis_nodes) // 2 + 1
 
     def __enter__(self):
-        self.acquire()
+        if not self.acquire():
+            raise RedLockError('failed to acquire lock')
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.release()

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,4 +1,4 @@
-from redlock import RedLock
+from redlock import RedLock, RedLockError
 import time
 
 
@@ -33,6 +33,15 @@ def test_context_manager():
     lock = RedLock("test_context_manager", [{"host": "localhost"}], ttl=1000)
     locked = lock.acquire()
     assert locked == True
+
+    # try to lock again within a with block
+    try:
+        with RedLock("test_context_manager", [{"host": "localhost"}]):
+            # shouldn't be allowed since someone has the lock already
+            assert False
+    except RedLockError:
+        # we expect this call to error out
+        pass
 
     lock.release()
 


### PR DESCRIPTION
Currently if the context manager is used it does not fail if the lock
cannot be acquired since the return isn't verified prior to leaving the
\__enter__ method. This change adds a test for that condition and raises a
RedLockError if the lock was not acquire-able.