### PR TITLE
Allow DSN-style url specification

### DIFF
--- a/redlock/lock.py
+++ b/redlock/lock.py
@@ -43,7 +43,11 @@ class RedLockFactory(object):
         self.redis_nodes = []
 
         for conn in connection_details:
-            node = redis.StrictRedis(**conn)
+            if 'url' in conn:
+                url = conn.pop('url')
+                node = redis.StrictRedis.from_url(url, **conn)
+            else:
+                node = redis.StrictRedis(**conn)
             node._release_script = node.register_script(RELEASE_LUA_SCRIPT)
             self.redis_nodes.append(node)
             self.quorum = len(self.redis_nodes) // 2 + 1
@@ -95,7 +99,11 @@ class RedLock(object):
             }]
 
         for conn in connection_details:
-            node = redis.StrictRedis(**conn)
+            if 'url' in conn:
+                url = conn.pop('url')
+                node = redis.StrictRedis.from_url(url, **conn)
+            else:
+                node = redis.StrictRedis(**conn)
             node._release_script = node.register_script(RELEASE_LUA_SCRIPT)
             self.redis_nodes.append(node)
         self.quorum = len(self.redis_nodes) // 2 + 1

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -12,3 +12,18 @@ def test_factory_create():
     assert lock.retry_times == 5
     assert lock.retry_delay == 100
     assert lock.factory == factory
+
+
+def test_factory_create_from_url():
+    factory = RedLockFactory([{"url": "redis://localhost/0"}])
+
+    lock = factory.create_lock(
+        "test_factory_create_from_url", ttl=500, retry_times=5, retry_delay=100
+    )
+
+    assert factory.redis_nodes == lock.redis_nodes
+    assert factory.quorum == lock.quorum
+    assert lock.ttl == 500
+    assert lock.retry_times == 5
+    assert lock.retry_delay == 100
+    assert lock.factory == factory

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -20,6 +20,16 @@ def test_simple_lock():
     assert locked == True
 
 
+def test_from_url():
+    """
+    Test a RedLock can be acquired via from_url.
+    """
+    lock = RedLock("test_from_url", [{"url": "redis://localhost/0"}], ttl=1000)
+    locked = lock.acquire()
+    lock.release()
+    assert locked == True
+
+
 def test_context_manager():
     """
     Test a RedLock can be released by the context manager automically.


### PR DESCRIPTION
redis-py (secretly) allows a [`.from_url`](https://github.com/andymccurdy/redis-py/blob/master/redis/client.py#L368) instantiation mode which is more
amenable to [12 factor app style configuration](http://12factor.net/config). This change checks for a `url`
specified in the `connection_details` and, if so, uses the `.from_url` mode.