### PR TITLE
Support passing in redis connections directly

### DIFF
--- a/redlock/lock.py
+++ b/redlock/lock.py
@@ -43,7 +43,9 @@ class RedLockFactory(object):
         self.redis_nodes = []
 
         for conn in connection_details:
-            if 'url' in conn:
+            if isinstance(conn, redis.StrictRedis):
+                node = conn
+            elif 'url' in conn:
                 url = conn.pop('url')
                 node = redis.StrictRedis.from_url(url, **conn)
             else:
@@ -99,7 +101,9 @@ class RedLock(object):
             }]
 
         for conn in connection_details:
-            if 'url' in conn:
+            if isinstance(conn, redis.StrictRedis):
+                node = conn
+            elif 'url' in conn:
                 url = conn.pop('url')
                 node = redis.StrictRedis.from_url(url, **conn)
             else:


### PR DESCRIPTION
This allows existing connections to be reused. It's helpful for integration into existing systems which are already using redis and don't want to create multiple connections. I my case, I'm using short-lived redis connections and I'd rather know that I'm shutting all of the connections down properly outside of my use of redlock.