### PR TITLE
Catch redis operation exception during lock acquire/release.

### DIFF
--- a/redlock/lock.py
+++ b/redlock/lock.py
@@ -131,14 +131,20 @@ class RedLock(object):
         """
         acquire a single redis node
         """
-        return node.set(self.resource, self.lock_key, nx=True, px=self.ttl)
+        try:
+            return node.set(self.resource, self.lock_key, nx=True, px=self.ttl)
+        except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError):
+            return False
 
     def release_node(self, node):
         """
         release a single redis node
         """
         # use the lua script to release the lock in a safe way
-        node._release_script(keys=[self.resource], args=[self.lock_key])
+        try:
+            node._release_script(keys=[self.resource], args=[self.lock_key])
+        except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError):
+            pass
 
     def acquire(self):
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -137,3 +137,17 @@ class TestLock(unittest.TestCase):
         self.redlock.assert_called_once_with('')
         self.redlock_acquire.assert_called_once_with()
         self.redlock_release.assert_not_called()
+
+
+def test_lock_with_multi_backend():
+    """
+    Test a RedLock can be acquired when at least N/2+1 redis instances are alive.
+    Set redis instance with port 6380 down or debug sleep during test.
+    """
+    lock = RedLock("test_simple_lock", connection_details=[
+        {"host": "localhost", "port": 6379, "db": 0, "socket_timeout": 0.2},
+        {"host": "localhost", "port": 6379, "db": 1, "socket_timeout": 0.2},
+        {"host": "localhost", "port": 6380, "db": 0, "socket_timeout": 0.2}], ttl=1000)
+    locked = lock.acquire()
+    lock.release()
+    assert locked == True


### PR DESCRIPTION
As the redlock can have more than one redis as backend and one or
more redis instances may be down or temporarily unavailable during
lock acquire or release. The redlock catches these redis exception
and marked this single acquire/release as failed.