### PR TITLE
Extend Functionality, Check Functionality, Reentrant Lock Changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
   - "2.7"
   - "2.6"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
@@ -10,7 +12,7 @@ install:
   - "pip install -r requirements-dev.txt"
 
 # command to run tests, e.g. python setup.py test
-script:  py.test
+script:  "py.test"
 
 services:
   - redis-server

--- a/redlock/lock.py
+++ b/redlock/lock.py
@@ -26,19 +26,38 @@ RELEASE_LUA_SCRIPT = """
     end
 """
 
+GET_TTL_LUA_SCRIPT = """
+    if redis.call("get",KEYS[1]) == ARGV[1] then
+        return redis.call("pttl",KEYS[1])
+    else
+        return 0
+    end
+"""
+
+# Reference:  http://redis.io/topics/distlock
+# Section Making the algorithm more reliable: Extending the lock
+BUMP_LUA_SCRIPT = """
+    if redis.call("get",KEYS[1]) == ARGV[1] then
+        return redis.call("pexpire",KEYS[1],ARGV[2])
+    else
+        return 0
+    end
+"""
+
 
 class RedLockError(Exception):
     pass
 
 
 class RedLockFactory(object):
+
     """
     A Factory class that helps reuse multiple Redis connections.
     """
 
     def __init__(self, connection_details):
         """
-
+        Create a new RedLockFactory
         """
         self.redis_nodes = []
 
@@ -51,6 +70,8 @@ class RedLockFactory(object):
             else:
                 node = redis.StrictRedis(**conn)
             node._release_script = node.register_script(RELEASE_LUA_SCRIPT)
+            node._bump_script = node.register_script(BUMP_LUA_SCRIPT)
+            node._get_ttl_script = node.register_script(GET_TTL_LUA_SCRIPT)
             self.redis_nodes.append(node)
             self.quorum = len(self.redis_nodes) // 2 + 1
 
@@ -80,7 +101,11 @@ class RedLock(object):
                  retry_delay=DEFAULT_RETRY_DELAY,
                  ttl=DEFAULT_TTL,
                  created_by_factory=False):
+        """
+        Create a new RedLock
+        """
 
+        self.lock_key = None
         self.resource = resource
         self.retry_times = retry_times
         self.retry_delay = retry_delay
@@ -109,6 +134,8 @@ class RedLock(object):
             else:
                 node = redis.StrictRedis(**conn)
             node._release_script = node.register_script(RELEASE_LUA_SCRIPT)
+            node._bump_script = node.register_script(BUMP_LUA_SCRIPT)
+            node._get_ttl_script = node.register_script(GET_TTL_LUA_SCRIPT)
             self.redis_nodes.append(node)
         self.quorum = len(self.redis_nodes) // 2 + 1
 
@@ -144,23 +171,49 @@ class RedLock(object):
         """
         # use the lua script to release the lock in a safe way
         try:
-            node._release_script(keys=[self.resource], args=[self.lock_key])
+            return node._release_script(keys=[self.resource], args=[self.lock_key])
+        except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError):
+            pass
+
+    def bump_node(self, node):
+        """
+        reset the ttl on a single redis node
+        """
+        try:
+            return node._bump_script(keys=[self.resource], args=[self.lock_key, self.ttl])
+        except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError):
+            pass
+
+    def get_ttl_from_node(self, node):
+        """
+        get the ttl of the key from a single node
+        """
+        try:
+            return node._get_ttl_script(keys=[self.resource], args=[self.lock_key])
         except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError):
             pass
 
     def acquire(self):
+        """
+        Attempt to acquire a new lock
+        """
         acquired, validity = self._acquire()
         return acquired
 
     def acquire_with_validity(self):
+        """
+        Attempt to acquire a new lock, and return lock validity time
+        """
         return self._acquire()
 
     def _acquire(self):
-
-        # lock_key should be random and unique
-        self.lock_key = uuid.uuid4().hex
-
         for retry in range(self.retry_times + 1):
+            # Hold onto the previous lock_key, just in case this
+            # acquire fails this Lock could still possibly be used
+            # to .extend() the lock it holds, or to reacquire it
+            # later after it has expired or had .release() called
+            previous_lock_key = self.lock_key
+            self.lock_key = uuid.uuid4().hex
             acquired_node_count = 0
             start_time = datetime.utcnow()
 
@@ -181,14 +234,96 @@ class RedLock(object):
             if acquired_node_count >= self.quorum and validity > 0:
                 return True, validity
             else:
+                # We didn't get the lock, be nice and release all
+                # the nodes, then sleep for a bit and retry if
+                # possible, else return False, 0
                 for node in self.redis_nodes:
                     self.release_node(node)
+                self.lock_key = previous_lock_key
                 time.sleep(random.randint(0, self.retry_delay) / 1000)
         return False, 0
 
-    def release(self):
+    def check(self):
+        """
+        Check to see if the lock is still held
+        """
+        return self.check_times()[0]
+
+    def check_times(self):
+        """
+        Return whether or not the lock is still held,
+        and how long each node reports the lock will be
+        held for, accounting for query time and clock drift
+        """
+        times = []
+        start_time = datetime.utcnow()
         for node in self.redis_nodes:
-            self.release_node(node)
+            y = self.get_ttl_from_node(node)
+            if y > 0:
+                times.append(y)
+        end_time = datetime.utcnow()
+        drift = (self.ttl * CLOCK_DRIFT_FACTOR) + 2
+        elapsed_milliseconds = self._total_ms(end_time - start_time)
+        # Compute times taking into account how long it took to query all
+        # the nodes as well as clock drift constant. Sort out any negative
+        # times (keys that may have expired while we were querying other nodes).
+        times = [x-(elapsed_milliseconds+drift) for x in times
+                 if x-(elapsed_milliseconds+drift) > 0]
+        if len(times) > 0:
+            return min(times) > 0 and len(times) >= self.quorum, times
+        return False, []
+
+    def release(self):
+        """
+        Release the lock
+
+        We can return whether or not we are sure the lock was actually
+        released by checking to see if the command output from a quorum
+        of the redis nodes, and return True/False based on that.
+        """
+        released = []
+        for node in self.redis_nodes:
+            released.append(self.release_node(node))
+        return len([x for x in released if x is not None]) >= self.quorum
+
+    def extend(self):
+        """
+        Extend the lifespan of the lock by returning its ttl to the original value
+        """
+        extended, validity = self._extend()
+        return extended
+
+    def extend_with_validity(self):
+        """
+        Extend the lifespan of the lock by returning its ttl to the original value
+
+        Also return the ttl of the lock
+        """
+        return self._extend()
+
+    def _extend(self):
+        # Returns whether or not the lock was extended succesfully -
+        # not whether or not the lock is held, which could conceivably
+        # be different values in strange cases.
+        # Extended implies held, held does not imply extended.
+        # The second entry in the returned tuple is the validity time
+        # if the lock was successfully extended or None if it wasn't.
+        # See "Making the algorithm more reliable: Extending the lock" here:
+        # https://redis.io/topics/distlock
+        for retry in range(self.retry_times + 1):
+            bumps = 0
+            start_time = datetime.utcnow()
+            for node in self.redis_nodes:
+                if self.bump_node(node):
+                    bumps += 1
+            end_time = datetime.utcnow()
+            elapsed_milliseconds = self._total_ms(end_time - start_time)
+            drift = (self.ttl * CLOCK_DRIFT_FACTOR) + 2
+            validity = self.ttl - (elapsed_milliseconds + drift)
+            if bumps >= self.quorum and validity > 0:
+                return True, validity
+            time.sleep(random.randint(0, self.retry_delay) / 1000)
+        return False, None
 
 
 class ReentrantRedLock(RedLock):
@@ -197,19 +332,50 @@ class ReentrantRedLock(RedLock):
         self._acquired = 0
 
     def acquire(self):
+        # Note: This function now checks the lock before calls when
+        # self._aquired > 0.
+        # If the lock has been lost it resets the acquired counter to 0 and
+        # automatically attempts to reacquire the lock. This means that
+        # number of calls to acquire == number of calls to release iff they
+        # are all made during the same lock lifespan. Eg the following would
+        # be possible
+        #
+        # >>> relock.acquire()
+        # True
+        # *the lock ttl goes by, we lose the lock without calling .release()*
+        # >>> relock.acquire()
+        # True
+        # >>> relock.release()
+        # True
+        # * the lock is actually released after the first call, because the *
+        # * first acquire call timed out *
+        #
+        # This is preferable, in my opinion, to calls to .acquire() returning True
+        # when the lock isn't actually held because it timed out.
+        if self._acquired > 0:
+            if self.check() is False:
+                self._acquired = 0
+            else:
+                self._acquired += 1
+                return True
+
         if self._acquired == 0:
             result = super(ReentrantRedLock, self).acquire()
-            if result:
+            if result is True:
                 self._acquired += 1
             return result
-        else:
+
+    def acquire_and_extend(self):
+        if self.extend() is True:
             self._acquired += 1
             return True
+        else:
+            if self.acquire():
+                return True
+        return False
 
     def release(self):
         if self._acquired > 0:
             self._acquired -= 1
             if self._acquired == 0:
                 return super(ReentrantRedLock, self).release()
-            return True
-        return False

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35
 
 [testenv]
 commands = py.test


### PR DESCRIPTION
Implements the following new functionality:
* Tests for python 3.5 and 3.6
* Relevant boolean return value for RedLock.release_node()
* Corresponding boolean return value for Redlock.release()
* RedLock.check(): Checks to see if a lock is still held, returning a boolean
* RedLock.check_times(): Checks to see if a lock is still held, and returns each nodes reported TTL for the lock
* RedLock.extend(): Tries to extend the TTL of a lock back up to it's original TTL
* RedLock.extend_with_validity(): Same as above, also returning the new lock TTL
* ReentrantRedLock.acquire_and_extend(): Acquires and extends (or just extends) a reentrant lock, incrementing the acquired counter.

Changes the following functionality:
* ReentrantRedLocks now respect lock timeouts

Added some doc strings and comments here and there.

Tests were altered because of the changes to ReentrantRedLock - in order to
test the functionality the tests now required a real lock, rather than a
mock. Tests were also added for new functionality.


