### PR TITLE
Fix to retry with given delay time, not with random time and to raise TimeoutException

### DIFF
--- a/redlock/lock.py
+++ b/redlock/lock.py
@@ -183,7 +183,12 @@ class RedLock(object):
             else:
                 for node in self.redis_nodes:
                     self.release_node(node)
-                time.sleep(random.randint(0, self.retry_delay) / 1000)
+
+                validity -= self.retry_delay
+                if validity > 0:
+                    time.sleep(self.retry_delay/1000)
+                else:
+                    RedLockError('Timeout error while trying to acquire lock')
         return False, 0
 
     def release(self):


### PR DESCRIPTION
As mentioned like https://github.com/glasslion/redlock/issues/13, 
Have modified to retry with the fixed delay time, not with random time between 0 ~ 200ms to avoid unluckily situation which could fail to acquire lock in zero seconds. And also modified to raise RedLockError when retry times has elapsed than TTL while retrying to acquire lock. In fact, not sure what the right way is, 'cause I'm newbie to here. 