### PR TITLE
Update Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
-  - "3.3"
+  - "3.7"
+  - "3.6"
+  - "3.5"
   - "3.4"
   - "2.7"
-  - "2.6"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ script:  py.test
 
 services:
   - redis-server
+
+matrix:
+  allow_failures:
+    - python: "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
 commands = py.test


### PR DESCRIPTION
New Pythons tested: 3.5, 3.6, 3.7
Pythons removed by being dead: 3.3, 2.6

Python 3.x versions lifespan checked on https://devguide.python.org/#status-of-python-branches

Right now, 3.7 is marked as "allow fail" because Travis have not this runtime available yet.