### PR TITLE
Implement RedLock.locked() check, as threading.Lock does

### DIFF
--- a/redlock/lock.py
+++ b/redlock/lock.py
@@ -129,6 +129,12 @@ class RedLock(object):
         delta_seconds = delta.seconds + delta.days * 24 * 3600
         return (delta.microseconds + delta_seconds * 10**6) / 10**3
 
+    def locked(self):
+        for node in self.redis_nodes:
+            if node.get(self.resource):
+                return True
+        return False
+
     def acquire_node(self, node):
         """
         acquire a single redis node

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -4,6 +4,8 @@ import mock
 import time
 import unittest
 
+import pytest
+
 
 def test_default_connection_details_value():
     """
@@ -21,6 +23,35 @@ def test_simple_lock():
     locked = lock.acquire()
     lock.release()
     assert locked == True
+
+
+def test_lock_is_locked():
+    lock = RedLock("test_lock_is_locked")
+    # Clear possible initial states
+    [node.delete(lock.resource) for node in lock.redis_nodes]
+
+    assert lock.locked() is False
+
+    lock.acquire()
+    assert lock.locked() is True
+
+    lock.release()
+    assert lock.locked() is False
+
+
+def test_locked_span_lock_instances():
+    lock1 = RedLock("test_locked_span_lock_instances")
+    lock2 = RedLock("test_locked_span_lock_instances")
+    # Clear possible initial states
+    [node.delete(lock1.resource) for node in lock1.redis_nodes]
+
+    assert lock1.locked() == lock2.locked() == False
+    lock1.acquire()
+
+    assert lock1.locked() == lock2.locked() == True
+
+    lock1.release()
+    assert lock1.locked() == lock2.locked() == False
 
 
 def test_lock_with_validity():


### PR DESCRIPTION
`threading.Lock` have a way to check if it is locked right now.

Implemented by checking if the `RedLock.resource` key is present in any redis node