### PR TITLE
RedLock.release() should be able to unlock other machine locks

### DIFF
--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -4,6 +4,8 @@ import mock
 import time
 import unittest
 
+import pytest
+
 
 def test_default_connection_details_value():
     """
@@ -21,6 +23,12 @@ def test_simple_lock():
     locked = lock.acquire()
     lock.release()
     assert locked == True
+
+
+def test_release_unlocked():
+    lock = RedLock("test_release_unlocked")
+    with pytest.raises(RuntimeError):
+        lock.release()
 
 
 def test_lock_with_validity():


### PR DESCRIPTION
As stated on https://docs.python.org/3.6/library/threading.html#threading.Lock.release, a lock should be able to unlock it whatever "Thread" it is right now.

However, the timeout stuff forced some flexibility: If an instance thinks that it is the sole owner of the locked resource, should not unlock it on `__exit__` for exemple.