### PR TITLE
Pin version of redis package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-redis
+redis==2.10.6


### PR DESCRIPTION
There was a bug in the latest version of redis package that caused our celery containers to crash. After inspecting the dependencies of all packages, we figured out that redlock hadn't pinned the version of redis due to which the version of redis got upgraded. 

celery issue for reference
https://github.com/celery/celery/issues/5175