### PR TITLE
Use 'dist: xenial' in Travis to add Python 3.7 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "3.7"
@@ -15,7 +16,3 @@ script:  py.test
 
 services:
   - redis-server
-
-matrix:
-  allow_failures:
-    - python: "3.7"


### PR DESCRIPTION
Travis officially added support for Xenial (with Python 3.7) on
2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release