### PR TITLE
PyPI now supports markdown long_description -- use it

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include AUTHORS.rst
 include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
-include README.rst
+include README.md
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ clean-build:
 	rm -fr build/
 	rm -fr dist/
 	rm -fr *.egg-info
-	-rm README.rst
 
 clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +
@@ -56,13 +55,10 @@ docs:
 	open docs/_build/html/index.html
 
 release: clean
-	pandoc --from=markdown_github --to=rst --output=README.rst README.md
 	python setup.py sdist upload
 	python setup.py bdist_wheel upload
-	-rm README.rst
 
 dist: clean
-	pandoc --from=markdown_github --to=rst --output=README.rst README.md
 	python setup.py sdist
 	python setup.py bdist_wheel
 	ls -l dist

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,8 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-try:
-    with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
-        long_description = f.read()
-except (OSError, IOError) as e:
-    # We use markdown for documentation. The restructured Text version 
-    # is only used for pypi.
-    long_description = ""
-
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
 
 setup(
     name='redlock',
@@ -24,6 +18,7 @@ setup(
 
     description='Distributed locks with Redis',
     long_description=long_description,
+    long_description_content_type='text/markdown',
 
     # The project's main homepage.
     url='https://github.com/glasslion/redlock',


### PR DESCRIPTION
Instead of converting `README.md` to rst, simply use the markdown version. setuptools and PyPI now support it as native format.

For full details, see:

https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/